### PR TITLE
Implement query parameter order

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,9 @@ const f = createFilterFactory({
 | Option | Type | Description | Default |
 |--------|------|-------------|---------|
 | `delimiter` | String | Character used to separate multiple values | `','` |
-| `onApply` | Function | Callback function triggered when filters are applied via `get()` | `undefined` |
+| `onApply` | Function | Callback function triggered when filters are applied via `get()` | 
+| `preserveQueryOrder` | Boolean | Preserves URL query parameter order when generating query objects | `true` |
+`undefined` |
 
 Example:
 ```js
@@ -120,6 +122,7 @@ const filters = useFilters(
 | `get()` | Triggers the onApply callback | None | void |
 | `toSearchParams()` | Converts filters to URLSearchParams | None | URLSearchParams object |
 | `toQueryObject(transformKeys?)` | Creates object with filter key-values | `transformKeys`: Boolean (default: true) | Object with filter parameters |
+| `toOrderedQueryObject(transformKeys?)` | Creates object with filter key-values, preserving URL parameter order | `transformKeys`: Boolean (default: true) | Object with ordered filter parameters |
 | `data()` | Returns plain object of filter values | None | Filter values object |
 | `has(filter, value)` | Checks if value exists in filter | `filter`: Filter key<br>`value`: Value to check | Boolean |
 | `clear(filterKey, shouldGet?)` | Resets filter(s) to default | `filterKey`: String/Array of keys<br>`shouldGet`: Boolean to trigger onApply | Void |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@veebisepad/vue-query-filters",
-    "version": "3.0.1",
+    "version": "3.3.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@veebisepad/vue-query-filters",
-            "version": "3.0.1",
+            "version": "3.3.0",
             "license": "MIT",
             "devDependencies": {
                 "typescript": "^4.9.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@veebisepad/vue-query-filters",
-    "version": "3.2.1",
+    "version": "3.3.0",
     "description": "Reactive utility for managing URL query parameters in Vue 3.",
     "main": "dist/index.js",
     "type": "module",

--- a/src/types/filters.ts
+++ b/src/types/filters.ts
@@ -68,6 +68,11 @@ export interface Options {
      * @param filters The query object with current filter values
      */
     onApply?(filters: QueryObject): void;
+    /**
+     * When true, preserves the order of query parameters as they appear in the URL
+     * @default true
+     */
+    preserveQueryOrder?: boolean;
 }
 
 /**
@@ -92,6 +97,14 @@ export interface FilterMethods<T extends Filters> {
      * @returns Object mapping filter keys to query string values
      */
     toQueryObject(transformKeys?: boolean): Record<string, string>;
+
+     /**
+     * Creates an object with filter keys and their string representations,
+     * preserving the order of parameters from the current URL
+     * @param transformKeys Whether to transform keys using the keyTransformer function
+     * @returns Object mapping filter keys to query string values in URL order
+     */
+     toOrderedQueryObject(transformKeys?: boolean): Record<string, string>;
 
     /**
      * Checks if a value exists in the specified filter


### PR DESCRIPTION
This pull request introduces a new feature to preserve the order of URL query parameters when generating query objects. It includes updates to the documentation, types, and the main `useFilters` function to support this feature.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L90-R92): Added `preserveQueryOrder` option to the filter options table and documented the new `toOrderedQueryObject` method. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L90-R92) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R125)

### Type Definitions:
* [`src/types/filters.ts`](diffhunk://#diff-20dee7a5d2084b0b9af879599a90473a3de467f95e652796543b0c865af552a7R71-R75): Updated the `Options` interface to include the `preserveQueryOrder` boolean property and added the `toOrderedQueryObject` method to the `FilterMethods` interface. [[1]](diffhunk://#diff-20dee7a5d2084b0b9af879599a90473a3de467f95e652796543b0c865af552a7R71-R75) [[2]](diffhunk://#diff-20dee7a5d2084b0b9af879599a90473a3de467f95e652796543b0c865af552a7R101-R108)

### Core Functionality:
* [`src/useFilters.ts`](diffhunk://#diff-ae285f011e0dbec74c5a5f57c7225c3e51da1ba4c52eef115d9cd1c944457b16L12-R12): Modified the `useFilters` function to set `preserveQueryOrder` to `true` by default and updated the `get` method to use `toOrderedQueryObject` if `preserveQueryOrder` is enabled. Added the `toOrderedQueryObject` method implementation. [[1]](diffhunk://#diff-ae285f011e0dbec74c5a5f57c7225c3e51da1ba4c52eef115d9cd1c944457b16L12-R12) [[2]](diffhunk://#diff-ae285f011e0dbec74c5a5f57c7225c3e51da1ba4c52eef115d9cd1c944457b16L38-R56)